### PR TITLE
Correctly format backticks in SCFormatText.

### DIFF
--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -157,6 +157,7 @@ endfunction
 function SCFormatText(text)
 	let l:text = substitute(a:text, '\', '\\\\', 'g')
 	let l:text = substitute(l:text, '"', '\\"', 'g')
+	let l:text = substitute(l:text, '`', '\\`', 'g')
   let l:text = '"' . l:text .'"'
 
   return l:text


### PR DESCRIPTION
This allows code that contains backticks to be run without error.
