### PR TITLE
Fix working directory

### DIFF
--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -73,7 +73,7 @@ module SC
           trap("INT") do
             Process.exit
           end
-          rundir = File.dirname(SC.sclang_path)
+          rundir = Dir.pwd
           IO.popen("cd #{rundir} && #{SC.sclang_path.chomp} -d #{rundir.chomp} -i scvim", "w") do |sclang|
             loop {
               x = `cat #{@@pipe_loc}`


### PR DESCRIPTION
SClang expects the working directory to be wherever the user started it from. This is important for loading resources, like this:

```
cd ~/tracks/foo
vi main.sc

(
  // Should load ~/tracks/foo/foo.wav, but tries to load /usr/bin/foo.wav and fails
  Buffer.load("foo.wav")
)
```

The patch restores this functionality.
