### PR TITLE
Set default SC commentstring to //

### DIFF
--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -21,6 +21,7 @@
 " You should have received a copy of the GNU General Public License
 " along with SCVIM.  If not, see <http://www.gnu.org/licenses/>.
  
+set commentstring=//\ %s
 
 " source the syntax file as it can change
 " so $SCVIM_DIR/syntax/supercollider.vim


### PR DESCRIPTION
Hello!

I propose that `scvim` sets the default Supercollider commentstring to `// `. I believe `// ` to be safer than `/* foo */` as it cannot be unintentionally ended mid comment by the the characters `*/`.

Cheers,
Louis