### PR TITLE
Use a split if we are inside tmux

### DIFF
--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -198,7 +198,15 @@ endfunction
 " ========================================================================================
 
 function SClangStart()
-  call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
+    if $TERM[0:5] == "screen"
+        if executable("tmux")
+            call system("tmux split-window -p 20 ; tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -U")
+        else
+            echo "Sorry, screen is not supported yet.."
+        endif
+    else
+        call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
+    endif
 endfunction
 
 function SClangKill()


### PR DESCRIPTION
Don't spawn a new terminal (app) when starting a scvim session
