### PR TITLE
check for pipe in vim

### DIFF
--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -200,6 +200,9 @@ endfunction
 let s:sclangStarted = 0
 
 function SClangStart()
+  if filereadable("/tmp/sclang-pipe")
+    echo "sclang is already running"
+  else
     if $TERM[0:5] == "screen"
         if executable("tmux")
             call system("tmux split-window -p 20 ; tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -U")
@@ -211,6 +214,7 @@ function SClangStart()
         call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
         let s:sclangStarted = 1
     endif
+  endif
 endfunction
 
 function SClangKill()


### PR DESCRIPTION
In Linux, launching SClangStart() twice will result in two concurrently running sclangs, both attached to the sclang pipe.

Both sclangs will write to the existing output window, while sending code with F5 or F6 will cause a race condition and it is random which of the two sclangs receives it.

I like to call this the two-headed demonic scvim, because you have no way of knowing that there are two sclangs attached to the same pipe. You only see that executing the same block of code behaves in two different ways at random. If the first sclang gets it, your code behaves like a while ago when when you started the second sclang by accident; if the second sclang gets it, it behaves properly, reflecting the changes you made to your classes before the last recompile. Only that you don't know this and you keep trying to reproduce nonexistant concurrency bugs in your classes, slowly losing faith in yourself, SuperCollider and the world in a terrible agonizing process. I only realized what was going on when an exception was thrown that I had recently re-worded and I got the old and new wordings at random. I have to say I had a somewhat hysterical but very good laugh then.

I have no idea why this happens, since the ruby script does properly check for the pipe file, but the easiest solution seems to be to simply check for the pipe file directly in vimscript.

The disadvantage is of course that the pipe path is now stored in two locations, in violation of the dry principle.

Due to extreme nastiness of the current behavior I would suggest to just accept this wart for now and tidy up later.

I don't have a perfect answer yet on how to tidy up; perhaps the pipe file name could be passed to the ruby script as a parameter. If you like this solution I can implement it.

Another good addition might be to make the pipe file name depend on the current vim process id (or a process-specific random string), so you could have one sclang per vim session, but not more. I'd like to hear your opinion on this too, if you would.
