### PR TITLE
Conditional kill

### DIFF
--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -63,7 +63,7 @@ endif
 
 if !exists("loaded_kill_sclang")
 	if s:sclangKillOnExit
-		au VimLeavePre * call SClangKill()
+		au VimLeavePre * call SClangKillIfStarted()
 	endif
 	let loaded_kill_sclang = 1
 endif
@@ -197,20 +197,30 @@ endfunction
 
 " ========================================================================================
 
+let s:sclangStarted = 0
+
 function SClangStart()
     if $TERM[0:5] == "screen"
         if executable("tmux")
             call system("tmux split-window -p 20 ; tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -U")
+            let s:sclangStarted = 1
         else
             echo "Sorry, screen is not supported yet.."
         endif
     else
         call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
+        let s:sclangStarted = 1
     endif
 endfunction
 
 function SClangKill()
   call system(s:sclangDispatcher . " -q")
+endfunction
+
+function SClangKillIfStarted()
+  if s:sclangStarted == 1
+    call SClangKill()
+  endif
 endfunction
 
 function SClangRecompile()


### PR DESCRIPTION
Currently, sclang will be killed when any vim session containing sc code closes.

With this patch, only closing the vim session that opened sclang will kill it. Closing any other vim session with sc code will have no effect.

This doesn't matter if using vim properly with buffers.

But if you use a different vim for each file in different terminals you wonder a lot why your sclang got killed.

The patch should have no effect when using only one vim with buffers.

Let me know if you want to pull but can't because you're not happy with coding style or other requirements, I'll happily fix it.
