### PR TITLE
Fix process buildup for ruby 2.3

### DIFF
--- a/bin/sc_dispatcher
+++ b/bin/sc_dispatcher
@@ -22,7 +22,7 @@ OptionParser.new do |opts|
      File.open(SC::Pipe.pid_loc, "r") do |file|
         d.interpret_silent("Server.quitAll;")
         pid = file.read.chomp
-        exec "kill -USR1 #{pid}"
+        Process.kill('USR1', pid.to_i)
      end
    end
 
@@ -31,7 +31,7 @@ OptionParser.new do |opts|
 
      File.open(SC::Pipe.pid_loc, "r") do |file|
         pid = file.read.chomp
-        exec "kill -INT #{pid}"
+        Process.kill('INT', pid.to_i)
      end
    end
 

--- a/bin/sc_dispatcher
+++ b/bin/sc_dispatcher
@@ -22,7 +22,7 @@ OptionParser.new do |opts|
      File.open(SC::Pipe.pid_loc, "r") do |file|
         d.interpret_silent("Server.quitAll;")
         pid = file.read.chomp
-        exec "kill -HUP #{pid}"
+        exec "kill -USR1 #{pid}"
      end
    end
 

--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -56,14 +56,13 @@ module SC
       private
 
       def prepare_pipe
-        File.open(@@pid_loc, "w"){ |f|
-          f.puts Process.pid
-        }
-
         if File.exists?(@@pipe_loc)
           warn "there is already a sclang session running, remove it first, than retry"
           exit
         end
+        File.open(@@pid_loc, "w"){ |f|
+          f.puts Process.pid
+        }
         system("mkfifo", @@pipe_loc)
       end
 

--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -75,10 +75,12 @@ module SC
           end
           rundir = Dir.pwd
           IO.popen("cd #{rundir} && #{SC.sclang_path.chomp} -d #{rundir.chomp} -i scvim", "w") do |sclang|
-            loop {
-              x = `cat #{@@pipe_loc}`
-              sclang.print x if x
-            }
+            File.open(@@pipe_loc, "r") do |f|
+              loop {
+                x = f.read 
+                sclang.print x if x
+              }
+            end
           end
         }
         $p = Process.fork { @@pipeproc.call }

--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -79,7 +79,7 @@ module SC
             end
           rescue SignalException => e
             # Exit on all signals except usr1, which restarts
-            unless e.signo == Signal.list["HUP"]
+            unless e.signo == Signal.list["USR1"]
               break
             end
           end

--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -68,12 +68,14 @@ module SC
 
       def run_pipe
         rundir = Dir.pwd
-        while true do
+        loop do
           begin
             IO.popen("#{SC.sclang_path.chomp} -d #{rundir.chomp} -i scvim", "w") do |sclang|
-              @f = File.open(@@pipe_loc, "r")
-              while x = @f.read do 
-                sclang.print x if x
+              loop do
+                File.open(@@pipe_loc, "r") do |f|
+                  x = f.read
+                  sclang.print x if x
+                end
               end
             end
           rescue SignalException => e

--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -73,7 +73,7 @@ module SC
       def run_pipe
         rundir = Dir.pwd
         while @done==false do
-          IO.popen("cd #{rundir} && #{SC.sclang_path.chomp} -d #{rundir.chomp} -i scvim", "w") do |sclang|
+          IO.popen("#{SC.sclang_path.chomp} -d #{rundir.chomp} -i scvim", "w") do |sclang|
             @f = File.open(@@pipe_loc, "r")
             begin
               while x = @f.read do 

--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -43,7 +43,6 @@ module SC
         prepare_pipe
         clean_up
         run_pipe
-        remove_files
       end
 
       def pipe_loc
@@ -88,6 +87,9 @@ module SC
       end
 
       def clean_up
+        at_exit do
+          remove_files
+        end
       end
 
       def remove_files

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -200,9 +200,6 @@ endfunction
 let s:sclangStarted = 0
 
 function SClangStart()
-  if filereadable("/tmp/sclang-pipe")
-    echo "sclang is already running"
-  else
     if $TERM[0:5] == "screen"
         if executable("tmux")
             call system("tmux split-window -p 20 ; tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -U")
@@ -214,7 +211,6 @@ function SClangStart()
         call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
         let s:sclangStarted = 1
     endif
-  endif
 endfunction
 
 function SClangKill()


### PR DESCRIPTION
In ruby 2.3, the problem of multiple instances of sclang being created resurfaced, but not only on SClangStart, but also on executing sclang code. It was impossible for me to make the process management in pipe.rb work reliably on 2.3, so I made the following modifications instead:

(1) Read sclang_pipe using ruby internals instead of cat (4e43caa)
(2) Read sclang_pipe in a loop without starting a seperate process. To handle the restart signal, close the ruby pipe handle and catch the exception. To handle the exit signal, do the same as restart but set the done flag to interrupt the loop. (a6581ab)
(3) As promised, revert my previous crude hotfix (955ab2d)

With this patch, scvim should now be more robust and easier to maintain, because the inherently difficult process housekeeping has been replaced by a single-process approach. I have been using it for a week with ruby 2.3 and it works perfectly, and I tested it in ruby versions 2.0, 2.1, 2.2 as well.

**Update**

Comment stream looks like a mess below, that's because I commented the patch, since it is fairly invasive. Comments [can be viewed in context here](https://github.com/sbl/scvim/pull/38/files).
