### PR TITLE
Look for sclang in the path used after 3.7

### DIFF
--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -19,8 +19,12 @@ module SC
       if File.exists?("/Applications/SuperCollider.app/Contents/Resources/sclang")
         return "/Applications/SuperCollider.app/Contents/Resources/sclang"
       else
-        warn "Could not find sclang executable.\nPlease make sure that SC is either installed at the default location e.g. '/Applications/SuperCollider.app' on a mac or add sclang to your shells search path."
-        exit
+        if File.exists?("/Applications/SuperCollider.app/Contents/MacOS/sclang")
+          return "/Applications/SuperCollider.app/Contents/MacOS/sclang"
+        else
+          warn "Could not find sclang executable.\nPlease make sure that SC is either installed at the default location e.g. '/Applications/SuperCollider.app' on a mac or add sclang to your shells search path."
+          exit
+        end
       end
     else
       return @@sclang_path


### PR DESCRIPTION
With this change it should work for old and new versions.