### PR TITLE
Look for sclang in the path used after 3.7

### DIFF
--- a/bin/scpipe/lib/sc/pipe.rb
+++ b/bin/scpipe/lib/sc/pipe.rb
@@ -18,6 +18,8 @@ module SC
     if @@sclang_path.empty?
       if File.exists?("/Applications/SuperCollider.app/Contents/Resources/sclang")
         return "/Applications/SuperCollider.app/Contents/Resources/sclang"
+      elsif File.exists?("/Applications/SuperCollider.app/Contents/MacOS/sclang")
+        return "/Applications/SuperCollider.app/Contents/MacOS/sclang"
       else
         warn "Could not find sclang executable.\nPlease make sure that SC is either installed at the default location e.g. '/Applications/SuperCollider.app' on a mac or add sclang to your shells search path."
         exit


### PR DESCRIPTION
With this change it should work for old and new versions.